### PR TITLE
Update WeakRef#initialize documentation

### DIFF
--- a/lib/weakref.rb
+++ b/lib/weakref.rb
@@ -30,9 +30,6 @@ class WeakRef < Delegator
 
   ##
   # Creates a weak reference to +orig+
-  #
-  # Raises an ArgumentError if the given +orig+ is immutable, such as Symbol,
-  # Integer, or Float.
 
   def initialize(orig)
     case orig


### PR DESCRIPTION
This is no longer true since https://bugs.ruby-lang.org/issues/16035
which landed in Ruy 2.7.0.

I'm not sure if it's best to remove that sentence or to add that it
only applies to 2.6 and older.