### PR TITLE
Add missing block parameter

### DIFF
--- a/lib/weakref.rb
+++ b/lib/weakref.rb
@@ -41,7 +41,7 @@ class WeakRef < Delegator
     super
   end
 
-  def __getobj__ # :nodoc:
+  def __getobj__(&_block) # :nodoc:
     @@__map[self] or defined?(@delegate_sd_obj) ? @delegate_sd_obj :
       Kernel::raise(RefError, "Invalid Reference - probably recycled", Kernel::caller(2))
   end


### PR DESCRIPTION
A block is part of the Delegator's contract. Ruby 3.4 issues a warning if a block is passed but unused. This commit fixes the warning by adding a block to the argument list.