### PR TITLE
weakref.gemspec: Drop gemspec config on executables

### DIFF
--- a/weakref.gemspec
+++ b/weakref.gemspec
@@ -26,8 +26,6 @@ Gem::Specification.new do |spec|
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
     `git ls-files -z 2>#{IO::NULL}`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
   spec.add_dependency "delegate"


### PR DESCRIPTION
This gem does not expose any executables.