### PR TITLE
Allow creating WeakRefs outside the main Ractor

### DIFF
--- a/lib/weakref.rb
+++ b/lib/weakref.rb
@@ -27,24 +27,24 @@ class WeakRef < Delegator
   class RefError < StandardError
   end
 
-  @@__map = ::ObjectSpace::WeakMap.new
-
   ##
   # Creates a weak reference to +orig+
 
   def initialize(orig)
     case orig
-    when true, false, nil
-      @delegate_sd_obj = orig
+    when true, false, nil, Symbol, Integer, Float, Complex, Rational
+      @weak = false
+      @store = orig
     else
-      @@__map[self] = orig
+      @weak = true
+      @store = ::ObjectSpace::WeakMap.new
+      @store[self] = orig
     end
-    super
   end
 
   def __getobj__(&_block) # :nodoc:
-    @@__map[self] or defined?(@delegate_sd_obj) ? @delegate_sd_obj :
-      Kernel::raise(RefError, "Invalid Reference - probably recycled", Kernel::caller(2))
+    return @store unless @weak
+    @store[self] or ::Kernel::raise(RefError, "Invalid Reference - probably recycled", ::Kernel::caller(2))
   end
 
   def __setobj__(obj) # :nodoc:
@@ -54,6 +54,6 @@ class WeakRef < Delegator
   # Returns true if the referenced object is still alive.
 
   def weakref_alive?
-    @@__map.key?(self) or defined?(@delegate_sd_obj)
+    !@weak || @store.key?(self)
   end
 end

--- a/test/test_weakref.rb
+++ b/test/test_weakref.rb
@@ -69,4 +69,18 @@ class TestWeakRef < Test::Unit::TestCase
       150_000.times { WeakRef.new(a) }
     end;
   end
+
+  if defined?(Ractor)
+    def test_weakref_ractor_creatable
+      warning = Warning[:experimental]
+      Warning[:experimental] = false
+      bug22105 = '[ruby-core:125705]'
+      assert_nothing_raised(Ractor::RemoteError, bug22105) do
+        ractor = Ractor.new { WeakRef.new(Object.new) }
+        Ractor.select(ractor)
+      end
+    ensure
+      Warning[:experimental] = warning
+    end
+  end
 end


### PR DESCRIPTION
Fix for https://bugs.ruby-lang.org/issues/22105

WeakRef instance can move between Ractors (also moving the object they reference if it isn't shareable).

They cannot be made shareable, as `ObjectSpace::WeakMap` cannot be made shareable.